### PR TITLE
Fix RX and TX pin switch

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -135,6 +135,12 @@ int main(void)
 
   /* USER CODE BEGIN 2 */
   HAL_GPIO_WritePin(GPIOA, GPIO_PIN_8, GPIO_PIN_RESET);
+  
+  /*Fix RX and TX pin switch by setting the following pins */
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_5, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_0, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_1, GPIO_PIN_SET);
+  HAL_GPIO_WritePin(GPIOA, GPIO_PIN_7, GPIO_PIN_SET);
 
   // reinitialize uart with speed from config
   huart2.Init.BaudRate = USART_DEBUG_SPEED;


### PR DESCRIPTION
The CH_PD pin is currently pulled low. This causes an error between the RX and TX pins. To confirm this, you need to connect the esp8266 to the PT1 with jumper wires and then switch the RX and TX pins. 

Setting the pins (which I have done in this commit) will fix this issue and the esp8266 and PT1 will be able to communicate just fine.

The hardware problem is either RX and TX pins are incorrect or CH_PD needs to be pulled high. Luckily, there is a software fix.
