### PR TITLE
Lepton 3 supported (with FFC and radiometry modes). This currently no…

### DIFF
--- a/Inc/lepton.h
+++ b/Inc/lepton.h
@@ -14,7 +14,7 @@
 #define FRAME_TOTAL_SIZE_RGB (FRAME_TOTAL_LENGTH * sizeof(uint8_t) * 3)
 #define IMAGE_NUM_LINES (60)
 #ifdef Y16
-#define TELEMETRY_NUM_LINES (3)
+#define TELEMETRY_NUM_LINES (1)
 #else
 #define TELEMETRY_NUM_LINES (0)
 #endif
@@ -117,6 +117,10 @@ typedef struct _lepton_buffer {
   lepton_status status;
 } lepton_buffer;
 
+#define NUM_SEGMENTS (4)
+typedef lepton_buffer frame_buffer[NUM_SEGMENTS];
+
+
 typedef struct __attribute__((packed)) _yuv422 {
   uint8_t uv;
   uint8_t y;
@@ -128,6 +132,7 @@ typedef struct __attribute__((packed)) _yuv422_buffer {
   yuv422_row_t data[IMAGE_NUM_LINES];
 } yuv422_buffer_t;
 
+void set_current_lepton_buffer(lepton_buffer *buff);
 lepton_status complete_lepton_transfer(lepton_buffer *);
 lepton_buffer* lepton_transfer(void);
 

--- a/Inc/lepton.h
+++ b/Inc/lepton.h
@@ -14,7 +14,11 @@
 #define FRAME_TOTAL_SIZE_RGB (FRAME_TOTAL_LENGTH * sizeof(uint8_t) * 3)
 #define IMAGE_NUM_LINES (60)
 #ifdef Y16
+  #ifndef LEPTON2 /* This is for Lepton 3 */
 #define TELEMETRY_NUM_LINES (1)
+  #else /* This is for Lepton 2 */
+#define TELEMETRY_NUM_LINES (3)
+  #endif
 #else
 #define TELEMETRY_NUM_LINES (0)
 #endif

--- a/Inc/project_config.h
+++ b/Inc/project_config.h
@@ -1,11 +1,11 @@
 #ifndef _PROJECT_CONFIG_H_
 #define _PROJECT_CONFIG_H_
 
-#define THERMAL_DATA_UART
-#define TMP007_OVERLAY
-#define SPLASHSCREEN_OVERLAY
-#define ENABLE_LEPTON_AGC
-// #define Y16
+//#define THERMAL_DATA_UART
+//#define TMP007_OVERLAY
+//#define SPLASHSCREEN_OVERLAY
+//#define ENABLE_LEPTON_AGC
+#define Y16
 
 #ifndef Y16
 // Values from LEP_PCOLOR_LUT_E in Middlewares/lepton_sdk/Inc/LEPTON_VID.h

--- a/Inc/tasks.h
+++ b/Inc/tasks.h
@@ -14,7 +14,7 @@ PT_THREAD( uart_lepton_send(struct pt *pt,char * buffer));
 PT_THREAD( rgb_to_yuv(struct pt *pt, lepton_buffer *restrict rgb, yuv422_buffer_t *restrict buffer));
 
 // Synchronization helpers
-uint32_t get_lepton_buffer(lepton_buffer **buffer);
+uint32_t get_frame_buffer(frame_buffer **buffer);
 uint32_t get_lepton_buffer_yuv(yuv422_buffer_t **buffer);
 
 //Other

--- a/Inc/tasks.h
+++ b/Inc/tasks.h
@@ -14,7 +14,11 @@ PT_THREAD( uart_lepton_send(struct pt *pt,char * buffer));
 PT_THREAD( rgb_to_yuv(struct pt *pt, lepton_buffer *restrict rgb, yuv422_buffer_t *restrict buffer));
 
 // Synchronization helpers
+#ifdef LEPTON2
+uint32_t get_lepton_buffer(lepton_buffer **buffer);
+#else /* Lepton 3 */
 uint32_t get_frame_buffer(frame_buffer **buffer);
+#endif
 uint32_t get_lepton_buffer_yuv(yuv422_buffer_t **buffer);
 
 //Other

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CMSIS_DEVSUP = $(CMSIS)/Device/ST/$(DEVICE_FAMILY)/
 CMSIS_OPT = -D$(DEVICE_TYPE) -DUSE_HAL_DRIVER
 OTHER_OPT = "-D__weak=__attribute__((weak))" "-D__packed=__attribute__((__packed__))" 
 
-LDSCRIPT = ./STM32F411CEUx_FLASH.ld
+LDSCRIPT = ./STM32F412CGUx_FLASH.ld
 
 SRCDIR := Src/
 INCDIR := Inc/

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ CMSIS_DEVSUP = $(CMSIS)/Device/ST/$(DEVICE_FAMILY)/
 CMSIS_OPT = -D$(DEVICE_TYPE) -DUSE_HAL_DRIVER
 OTHER_OPT = "-D__weak=__attribute__((weak))" "-D__packed=__attribute__((__packed__))" 
 
-LDSCRIPT = ./STM32F412CGUx_FLASH.ld
+ifndef STM32F411CEU
+	LDSCRIPT = ./STM32F412CGUx_FLASH.ld
+else
+	LDSCRIPT = ./STM32F411CEUx_FLASH.ld
+endif
 
 SRCDIR := Src/
 INCDIR := Inc/
@@ -61,6 +65,9 @@ endif
 ifdef USART_DEBUG
 	USART_DEBUG_SPEED ?= 115200
 	CFLAGS += -DUSART_DEBUG -DUSART_DEBUG_SPEED=$(USART_DEBUG_SPEED)
+endif
+ifdef LEPTON2
+	CFLAGS += -DLEPTON2
 endif
 ASFLAGS = $(CFLAGS) -x assembler-with-cpp
 LDFLAGS = -Wl,--gc-sections,-Map=$*.map,-cref -fno-short-enums -Wl,--no-enum-size-warning -T $(LDSCRIPT) $(CPU)

--- a/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/usbd_uvc.h
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/usbd_uvc.h
@@ -63,6 +63,8 @@
 #define VIDEO_PACKET_SIZE                             ((unsigned int)(482))
 #define VIDEO_MAX_SETUP_PACKET_SIZE                   ((unsigned int)(1024))
 #define CMD_PACKET_SIZE                               ((unsigned int)(8))
+#define OUTPUT_LINES								  (120)
+#define OUTPUT_LINE_LENGTH							  (160)
 
 #define CAM_FPS                                       9
 

--- a/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/usbd_uvc.h
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/usbd_uvc.h
@@ -63,8 +63,13 @@
 #define VIDEO_PACKET_SIZE                             ((unsigned int)(482))
 #define VIDEO_MAX_SETUP_PACKET_SIZE                   ((unsigned int)(1024))
 #define CMD_PACKET_SIZE                               ((unsigned int)(8))
-#define OUTPUT_LINES								  (120)
-#define OUTPUT_LINE_LENGTH							  (160)
+#ifdef LEPTON2
+  #define OUTPUT_LINES      	(60)  
+  #define OUTPUT_LINE_LENGTH    (80)
+#else
+  #define OUTPUT_LINES		(120)
+  #define OUTPUT_LINE_LENGTH	(160)
+#endif
 
 #define CAM_FPS                                       9
 

--- a/Middlewares/ST/STM32_USB_Device_Library/Class/video/Src/usbd_uvc.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/video/Src/usbd_uvc.c
@@ -501,38 +501,38 @@ __ALIGN_BEGIN struct usbd_uvc_cfg USBD_UVC_CfgFSDesc __ALIGN_END =
   .uvc_vs_frames_formats = {
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(YUYV, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, YUYV, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, YUYV, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(Y16, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, Y16, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, Y16, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(NV12, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, NV12, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, NV12, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(YU12, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, YU12, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, YU12, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(GREY, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, GREY, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, GREY, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
 #ifndef Y16
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(RGB565, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, RGB565, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, RGB565, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
     {
       .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(BGR3, 1),
-      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, BGR3, 80, 60),
+      .uvc_vs_frame  = UVC_FRAME_FORMAT(1, BGR3, OUTPUT_LINE_LENGTH, OUTPUT_LINES),
       .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),
     },
 #endif

--- a/STM32F412CGUx_FLASH.ld
+++ b/STM32F412CGUx_FLASH.ld
@@ -1,0 +1,188 @@
+/*
+*****************************************************************************
+**
+
+**  File        : LinkerScript.ld
+**
+**  Abstract    : Linker script for STM32F411CEUx Device with
+**                512KByte FLASH, 128KByte RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+*****************************************************************************
+** @attention
+**
+** <h2><center>&copy; COPYRIGHT(c) 2014 Ac6</center></h2>
+**
+** Redistribution and use in source and binary forms, with or without modification,
+** are permitted provided that the following conditions are met:
+**   1. Redistributions of source code must retain the above copyright notice,
+**      this list of conditions and the following disclaimer.
+**   2. Redistributions in binary form must reproduce the above copyright notice,
+**      this list of conditions and the following disclaimer in the documentation
+**      and/or other materials provided with the distribution.
+**   3. Neither the name of Ac6 nor the names of its contributors
+**      may be used to endorse or promote products derived from this software
+**      without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+*****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = 0x20040000;    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}
+
+

--- a/Src/lepton.c
+++ b/Src/lepton.c
@@ -25,11 +25,25 @@ extern SPI_HandleTypeDef hspi2;
 
 static lepton_xfer_state xfer_state = LEPTON_XFER_STATE_START;
 lepton_buffer *current_lepton_buffer = NULL;
+#ifdef LEPTON2
+#define RING_SIZE (4)
+lepton_buffer lepton_buffers[RING_SIZE];
+static uint32_t current_buffer_index = 0;
+
+lepton_buffer* get_next_lepton_buffer()
+{
+  current_buffer_index = ((current_buffer_index + 1) % RING_SIZE);
+  lepton_buffer* packet = &lepton_buffers[current_buffer_index];
+  packet->status = LEPTON_STATUS_OK;
+  return packet;
+}
+#else
+
 
 void set_current_lepton_buffer(lepton_buffer *buff){
 	current_lepton_buffer = buff;
 }
-
+#endif
 // These replace HAL library functions as they're a lot shorter and more specialized
 static inline HAL_StatusTypeDef start_lepton_spi_dma(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
 static inline HAL_StatusTypeDef setup_lepton_spi_rx(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
@@ -52,25 +66,34 @@ lepton_buffer* lepton_transfer(void)
 	{
 	default:
 	case LEPTON_XFER_STATE_START:
+#ifdef LEPTON2
+		buf = get_next_lepton_buffer();
+#endif
 		status = setup_lepton_spi_rx(&hspi2, (uint8_t*)(&buf->lines[0]), FRAME_TOTAL_LENGTH);
 		break;
 	case LEPTON_XFER_STATE_SYNC:
+#ifdef LEPTON2
+		buf = &lepton_buffers[current_buffer_index];
+#endif
 		status = setup_lepton_spi_rx(&hspi2, (uint8_t*)(&buf->lines[0]), FRAME_TOTAL_LENGTH);
 		break;
 	case LEPTON_XFER_STATE_DATA:
+#ifdef LEPTON2
+		buf = &lepton_buffers[current_buffer_index];
+#endif
 		status = setup_lepton_spi_rx(&hspi2, (uint8_t*)(&buf->lines[1]), FRAME_TOTAL_LENGTH * (IMAGE_NUM_LINES + TELEMETRY_NUM_LINES - 1));
 		break;
 	}
 
-	if (status != HAL_OK)
-	{
-		DEBUG_PRINTF("Error setting up SPI DMA receive: %d\r\n", status);
-		buf->status = LEPTON_STATUS_RESYNC;
-		return buf;
-	}
+  if (status != HAL_OK)
+  {
+    DEBUG_PRINTF("Error setting up SPI DMA receive: %d\r\n", status);
+    buf->status = LEPTON_STATUS_RESYNC;
+    return buf;
+  }
 
-	buf->status = LEPTON_STATUS_TRANSFERRING;
-	return buf;
+  buf->status = LEPTON_STATUS_TRANSFERRING;
+  return buf;
 }
 
 void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
@@ -122,6 +145,16 @@ static void lepton_spi_rx_dma_cplt(DMA_HandleTypeDef *hdma)
 
 void lepton_init(void )
 {
+#ifdef LEPTON2
+  int i;
+  for (i = 0; i < RING_SIZE; i++)
+  {
+    lepton_buffers[i].number = i;
+    lepton_buffers[i].status = LEPTON_STATUS_OK;
+    DEBUG_PRINTF("Initialized lepton buffer %d @ %p\r\n", i, &lepton_buffers[i]);
+  }
+#endif
+
 	LEPTON_RESET_L_LOW;
   LEPTON_PW_DWN_LOW;
 

--- a/Src/lepton_i2c.c
+++ b/Src/lepton_i2c.c
@@ -259,6 +259,74 @@ HAL_StatusTypeDef enable_rgb888(LEP_PCOLOR_LUT_E pcolor_lut)
   return HAL_OK;
 }
 
+HAL_StatusTypeDef enable_user_ffc_mode()
+{
+	LEP_RESULT result;
+	LEP_SYS_FFC_SHUTTER_MODE_OBJ_T shutterModeObj;
+
+	result = LEP_GetSysFfcShutterModeObj( &hport_desc, &shutterModeObj );
+	if( result != LEP_OK ) {
+		DEBUG_PRINTF("Could not get Sys FFC shutter mode object %d\r\n", result);
+		return HAL_ERROR;
+	}
+
+	shutterModeObj.shutterMode = LEP_SYS_FFC_SHUTTER_MODE_MANUAL;
+	shutterModeObj.desiredFfcPeriod = shutterModeObj.desiredFfcPeriod * 6; // Every half hour
+	shutterModeObj.explicitCmdToOpen = LEP_TRUE;
+
+	result = LEP_SetSysFfcShutterModeObj( &hport_desc, shutterModeObj );
+	if( result != LEP_OK ) {
+		DEBUG_PRINTF("Could not get Sys FFC shutter mode object %d\r\n", result);
+		return HAL_ERROR;
+	}
+
+	return HAL_OK;
+}
+
+int lepton_rad_enable() {
+	int error = 0;
+
+	error =  LEP_SetRadEnableState( &hport_desc, LEP_RAD_ENABLE);
+	if (error != LEP_OK) {
+			return error;
+	} else if (error == LEP_OK ) {
+			DEBUG_PRINTF("Rad mode enabled." );
+	}
+	return 0;
+}
+
+int lepton_rad_disable() {
+	int error = 0;
+
+    error = LEP_SetRadEnableState( &hport_desc, LEP_RAD_DISABLE);
+	if (error != LEP_OK) {
+		return error;
+	} else if (error == LEP_OK){
+		DEBUG_PRINTF( "Rad mode disabled." );
+	}
+	return 0;
+}
+
+int lepton_get_rad_state() {
+	LEP_UINT32 enableState = 0;
+	LEP_RAD_ENABLE_E_PTR radEnableStatePtr = &enableState;
+
+	radEnableStatePtr = (LEP_RAD_ENABLE_E_PTR)malloc(sizeof(LEP_UINT32));
+	int error;
+	if ((error = LEP_GetRadEnableState( &hport_desc, radEnableStatePtr))!= LEP_OK) {
+		DEBUG_PRINTF("Error=%x, in rad state.",error);
+		return error;
+	}
+	else {
+		DEBUG_PRINTF("Rad enable state variale= %x", *radEnableStatePtr );
+	}
+
+	return 0;
+}
+
+
+
+
 // HAL_OK       = 0x00,
 //  HAL_ERROR    = 0x01,
 //  HAL_BUSY     = 0x02,
@@ -292,6 +360,12 @@ HAL_StatusTypeDef init_lepton_command_interface(void)
 
   if (print_aux_temp_celcius() != HAL_OK)
     return HAL_ERROR;
+
+  if (enable_user_ffc_mode() != HAL_OK)
+	 return HAL_ERROR;
+
+  if (lepton_rad_enable() != HAL_OK)
+	return HAL_ERROR;
 
   return HAL_OK;
 }

--- a/Src/lepton_task.c
+++ b/Src/lepton_task.c
@@ -35,19 +35,25 @@ struct rgb_to_yuv_state {
 #define DEBUG_PRINTF(...)
 #endif
 
+#define NUM_FRAMES_BUFFERED (3)
+frame_buffer lepton_buffers[NUM_FRAMES_BUFFERED];
 
-uint32_t get_lepton_buffer(lepton_buffer **buffer)
-{
-  if (buffer != NULL)
-    *buffer = completed_buffer;
-	return completed_frame_count;
+int inprogress_index = 0;
+int pending_segment = 0;
+
+static inline next_frame(int idx){
+	return (idx + 1) % NUM_FRAMES_BUFFERED;
+}
+static inline prev_frame(int idx){
+	return (idx + NUM_FRAMES_BUFFERED - 1) % NUM_FRAMES_BUFFERED;
 }
 
-uint32_t get_lepton_buffer_yuv(yuv422_buffer_t **buffer)
+
+uint32_t get_frame_buffer(frame_buffer **buffer)
 {
   if (buffer != NULL)
-    *buffer = &yuv_buffers[completed_yuv_frame_count%2];
-	return completed_yuv_frame_count;
+    *buffer = &lepton_buffers[prev_frame(inprogress_index)];
+	return completed_frame_count;
 }
 
 void init_lepton_state(void);
@@ -90,7 +96,9 @@ PT_THREAD( lepton_task(struct pt *pt))
 
 	while (1)
 	{
-		current_buffer = lepton_transfer();
+		current_buffer = &lepton_buffers[inprogress_index][pending_segment];
+		set_current_lepton_buffer(current_buffer);
+		lepton_transfer();
 
 		transferring_timer = HAL_GetTick();
 		PT_YIELD_UNTIL(pt, current_buffer->status != LEPTON_STATUS_TRANSFERRING || ((HAL_GetTick() - transferring_timer) > 200));
@@ -139,25 +147,21 @@ PT_THREAD( lepton_task(struct pt *pt))
 			last_logged_count = current_frame_count;
 		}
 
+		int segment_number = (current_buffer->lines[20].header[0] >> 12) & 0x7;
+		int segment_index = segment_number - 1; // number = 0, index = -1 indicates that this is a repeat
+
 		// Need to update completed buffer for clients?
-#ifdef Y16
-		if (completed_frame_count != current_frame_count)
-#else
-		if ((current_frame_count % 3) == 0)
-#endif
-		{
-			completed_buffer = current_buffer;
-			completed_frame_count = current_frame_count;
-
-			HAL_GPIO_TogglePin(SYSTEM_LED_GPIO_Port, SYSTEM_LED_Pin);
-
-#ifndef Y16
-			PT_SPAWN(
-				pt,
-				&rgb_to_yuv_pt,
-				rgb_to_yuv(&rgb_to_yuv_pt, completed_buffer, &yuv_buffers[(completed_yuv_frame_count + 1) % 2])
-			);
-#endif
+		if (pending_segment == segment_index){
+			if(pending_segment == 3){
+				completed_frame_count ++;
+				HAL_GPIO_TogglePin(SYSTEM_LED_GPIO_Port, SYSTEM_LED_Pin);
+				inprogress_index = next_frame(inprogress_index);
+				pending_segment = 0;
+			}else{
+				pending_segment ++;
+			}
+		}else{
+			pending_segment = 0;
 		}
 	}
 	PT_END(pt);

--- a/Src/main.c
+++ b/Src/main.c
@@ -241,7 +241,7 @@ void SystemClock_Config(void)
                               |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
-  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV4;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
   if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_3) != HAL_OK)
   {

--- a/Src/usb_task.c
+++ b/Src/usb_task.c
@@ -28,7 +28,7 @@ void change_overlay_mode(void)
 
 static int last_frame_count;
 #ifdef Y16
-static lepton_buffer *last_buffer;
+static frame_buffer *last_buffer;
 #else
 static yuv422_buffer_t *last_buffer;
 static lepton_buffer *last_buffer_rgb;
@@ -217,7 +217,7 @@ static void scale_image_8bit(yuv422_buffer_t *buffer, uint16_t min, uint16_t max
 }
 #endif
 
-PT_THREAD( usb_task(struct pt *pt))
+PT_THREAD(usb_task(struct pt *pt))
 {
 	static int temperature;
 	static uint16_t count = 0, i;
@@ -226,7 +226,8 @@ PT_THREAD( usb_task(struct pt *pt))
 #endif
 
 	static uint8_t uvc_header[2] = { 2, 0 };
-	static uint32_t uvc_xmit_row = 0, uvc_xmit_plane = 0;
+	static uint32_t uvc_xmit_row = 0;
+	static uint32_t lepton_lines_sent = 0;
 	static uint8_t packet[VIDEO_PACKET_SIZE];
 
 	PT_BEGIN(pt);
@@ -239,13 +240,75 @@ PT_THREAD( usb_task(struct pt *pt))
 	while (1)
 	{
 #ifdef Y16
-		PT_WAIT_UNTIL(pt, get_lepton_buffer(NULL) != last_frame_count);
-		last_frame_count = get_lepton_buffer(&last_buffer);
+		PT_WAIT_UNTIL(pt, get_frame_buffer(NULL) != last_frame_count);
+		last_frame_count = get_frame_buffer(&last_buffer);
 #else
 		PT_WAIT_UNTIL(pt, get_lepton_buffer_yuv(NULL) != last_frame_count);
 		last_frame_count = get_lepton_buffer_yuv(&last_buffer);
 		get_lepton_buffer(&last_buffer_rgb);
 #endif
+
+		// perform stream initialization
+		if (uvc_stream_status == 1)
+		{
+			DEBUG_PRINTF("Starting UVC stream...\r\n");
+
+			uvc_header[0] = 2;
+			uvc_header[1] = 0;
+			UVC_Transmit_FS(uvc_header, 2);
+
+			uvc_stream_status = 2;
+			uvc_xmit_row = 0;
+			lepton_lines_sent = 0;
+		}
+
+		// put image on stream as long as stream is open
+		while (uvc_stream_status == 2)
+		{
+			count = 0;
+
+			packet[count++] = uvc_header[0];
+			packet[count++] = uvc_header[1];
+
+			while (uvc_xmit_row < OUTPUT_LINES && count + VS_FMT_SIZE(Y16)/8 * OUTPUT_LINE_LENGTH < VIDEO_PACKET_SIZE)
+			{
+				for (int j = 0; j < 2; j++){
+					// 61 because lepton 3 with telemetry sends 61 lines per segment
+					// with the first 3 having 61 data lines, and the last one having 57 data lines
+					// the last 4 lines of the 4th segment are telemetry
+					int segment_index = lepton_lines_sent / 61;
+					for (i = 0; i < FRAME_LINE_LENGTH; i++)
+					{
+						uint16_t val = (*last_buffer)[segment_index].lines[IMAGE_OFFSET_LINES + lepton_lines_sent % 61].data.image_data[i];
+						packet[count++] = (uint8_t)((val >> 0) & 0xFF);
+						packet[count++] = (uint8_t)((val >> 8) & 0xFF);
+					}
+
+					lepton_lines_sent++;
+				}
+				uvc_xmit_row++;
+			}
+			if (uvc_xmit_row == OUTPUT_LINES){
+				packet[1] |= 0x2;
+			}
+
+			int retries = 1000;
+			while (UVC_Transmit_FS(packet, count) == USBD_BUSY && uvc_stream_status == 2)
+			{
+				if (--retries == 0) {
+					break;
+				}
+			}
+
+			if (packet[1] & 0x2)
+			{
+				uvc_header[1] ^= 1; // toggle bit 0 for next new frame
+				uvc_xmit_row = 0;
+				lepton_lines_sent = 0;
+				break;
+			}
+			PT_YIELD(pt);
+		}
 
 #ifndef ENABLE_LEPTON_AGC
 		switch (videoCommitControl.bFormatIndex)
@@ -295,271 +358,7 @@ PT_THREAD( usb_task(struct pt *pt))
 			}
 #endif
 		}
-
-
-
-    // perform stream initialization
-    if (uvc_stream_status == 1)
-    {
-      DEBUG_PRINTF("Starting UVC stream...\r\n");
-
-      uvc_header[0] = 2;
-      uvc_header[1] = 0;
-      UVC_Transmit_FS(uvc_header, 2);
-
-      uvc_stream_status = 2;
-      uvc_xmit_row = 0;
-      uvc_xmit_plane = 0;
-    }
-
-    // put image on stream as long as stream is open
-    while (uvc_stream_status == 2)
-    {
-      count = 0;
-
-      packet[count++] = uvc_header[0];
-      packet[count++] = uvc_header[1];
-
-      switch (videoCommitControl.bFormatIndex)
-      {
-        // HACK: NV12 is semi-planar but YU12/I420 is planar. Deal with it when we have actual color.
-        case VS_FMT_INDEX(NV12):
-        case VS_FMT_INDEX(YU12):
-        {
-          // printf("Writing format 1, plane %d...\r\n", uvc_xmit_plane);
-
-          switch (uvc_xmit_plane)
-          {
-            default:
-            case 0: // Y
-            {
-              // while (uvc_xmit_row < 60 && count < VALDB(videoCommitControl.dwMaxPayloadTransferSize))
-              while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-              {
-                for (i = 0; i < FRAME_LINE_LENGTH; i++)
-                {
-#ifdef Y16
-                  uint16_t val = last_buffer->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-#else
-                  uint8_t val = last_buffer->data[uvc_xmit_row][i].y;
-#endif
-                  // AGC is on so just use lower 8 bits
-                  packet[count++] = (uint8_t)val;
-                }
-
-                uvc_xmit_row++;
-              }
-
-              if (uvc_xmit_row == IMAGE_NUM_LINES)
-              {
-                uvc_xmit_plane = 1;
-                uvc_xmit_row = 0;
-              }
-
-              break;
-            }
-            case 1: // VU
-            case 2:
-            {
-              int incr = (videoCommitControl.bFormatIndex == VS_FMT_INDEX(NV12) ? 1 : 2);
-              int plane_offset = uvc_xmit_plane - 1;
-
-              while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-              {
-                for (i = 0; i < FRAME_LINE_LENGTH && uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE; i += incr)
-                {
-#ifdef Y16
-                  packet[count++] = 128;
-#else
-                  packet[count++] = last_buffer->data[uvc_xmit_row][i + plane_offset].uv;
-#endif
-                }
-
-                uvc_xmit_row += 2;
-              }
-
-              // plane is done
-              if (uvc_xmit_row == IMAGE_NUM_LINES)
-              {
-                if (uvc_xmit_plane == 1 && videoCommitControl.bFormatIndex == VS_FMT_INDEX(YU12))
-                {
-                  uvc_xmit_plane = 2;
-                  uvc_xmit_row = 0;
-                }
-                else
-                {
-                  packet[1] |= 0x2; // Flag end of frame
-                }
-              }
-              break;
-            }
-          }
-  
-          break;
-        }
-        case VS_FMT_INDEX(GREY):
-        {
-          // while (uvc_xmit_row < 60 && count < VALDB(videoCommitControl.dwMaxPayloadTransferSize))
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            for (i = 0; i < FRAME_LINE_LENGTH; i++)
-            {
-#ifdef Y16
-              uint16_t val = last_buffer->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-#else
-              uint8_t val = last_buffer->data[uvc_xmit_row][i].y;
-#endif
-              // AGC is on, so just use lower 8 bits
-              packet[count++] = (uint8_t)val;
-            }
-
-            uvc_xmit_row++;
-          }
-
-          // image is done
-          if (uvc_xmit_row == IMAGE_NUM_LINES)
-          {
-            packet[1] |= 0x2; // Flag end of frame
-          }
-
-          break;
-        }
-        case VS_FMT_INDEX(Y16):
-        {
-          // while (uvc_xmit_row < 60 && count < VALDB(videoCommitControl.dwMaxPayloadTransferSize))
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            for (i = 0; i < FRAME_LINE_LENGTH; i++)
-            {
-#ifdef Y16
-              uint16_t val = last_buffer->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-#else
-              uint16_t val = last_buffer->data[uvc_xmit_row][i].y;
-#endif
-              packet[count++] = (uint8_t)((val >> 0) & 0xFF);
-              packet[count++] = (uint8_t)((val >> 8) & 0xFF);
-            }
-
-            uvc_xmit_row++;
-          }
-
-          // image is done
-          if (uvc_xmit_row == IMAGE_NUM_LINES)
-          {
-            packet[1] |= 0x2; // Flag end of frame
-          }
-
-          break;
-        }
-        default:
-        case VS_FMT_INDEX(YUYV):
-        {
-#ifdef Y16
-          // while (uvc_xmit_row < 60 && count < VALDB(videoCommitControl.dwMaxPayloadTransferSize))
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            for (i = 0; i < FRAME_LINE_LENGTH; i++)
-            {
-              uint16_t val = last_buffer->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-              // AGC is on so just use lower 8 bits
-              packet[count++] = (uint8_t)val;
-              packet[count++] = 128;
-            }
-
-            uvc_xmit_row++;
-          }
-#else
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            memcpy(&packet[count], last_buffer->data[uvc_xmit_row], sizeof(yuv422_row_t));
-            count += sizeof(yuv422_row_t);
-            uvc_xmit_row++;
-          }
-#endif
-
-          // image is done
-          if (uvc_xmit_row == IMAGE_NUM_LINES)
-          {
-            packet[1] |= 0x2; // Flag end of frame
-          }
-
-          break;
-        }
-#ifndef Y16
-        case VS_FMT_INDEX(BGR3):
-        {
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            for (i = 0; i < FRAME_LINE_LENGTH; i++)
-            {
-              rgb_t rgb = last_buffer_rgb->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-              packet[count++] = rgb.b;
-              packet[count++] = rgb.g;
-              packet[count++] = rgb.r;
-            }
-            uvc_xmit_row++;
-          }
-
-          // image is done
-          if (uvc_xmit_row == IMAGE_NUM_LINES)
-          {
-            packet[1] |= 0x2; // Flag end of frame
-          }
-
-          break;
-        }
-        case VS_FMT_INDEX(RGB565):
-        {
-          while (uvc_xmit_row < IMAGE_NUM_LINES && count < VIDEO_PACKET_SIZE)
-          {
-            for (i = 0; i < FRAME_LINE_LENGTH; i++)
-            {
-              rgb_t rgb = last_buffer_rgb->lines[IMAGE_OFFSET_LINES + uvc_xmit_row].data.image_data[i];
-              uint16_t val =
-                ((rgb.r >> 3) << 11) |
-                ((rgb.g >> 2) <<  5) |
-                ((rgb.b >> 3) <<  0);
-
-              packet[count++] = (val >> 0) & 0xff;
-              packet[count++] = (val >> 8) & 0xff;
-            }
-            uvc_xmit_row++;
-          }
-
-          // image is done
-          if (uvc_xmit_row == IMAGE_NUM_LINES)
-          {
-            packet[1] |= 0x2; // Flag end of frame
-          }
-
-          break;
-        }
-#endif
-      }
-
-      // printf("UVC_Transmit_FS(): packet=%p, count=%d\r\n", packet, count);
-      // fflush(stdout);
-
-      int retries = 1000;
-      while (UVC_Transmit_FS(packet, count) == USBD_BUSY && uvc_stream_status == 2)
-      {
-        if (--retries == 0) {
-//          DEBUG_PRINTF("UVC_Transmit_FS() failed (no one is acking)\r\n");
-          break;
-        }
-      }
-
-      if (packet[1] & 0x2)
-      {
-        uvc_header[1] ^= 1; // toggle bit 0 for next new frame
-        uvc_xmit_row = 0;
-        uvc_xmit_plane = 0;
-        // DEBUG_PRINTF("Frame complete\r\n");
-        break;
-      }
-      PT_YIELD(pt);
-    }
-    PT_YIELD(pt);
+		PT_YIELD(pt);
 	}
 	PT_END(pt);
 }

--- a/Src/usbd_uvc_if.c
+++ b/Src/usbd_uvc_if.c
@@ -112,7 +112,7 @@ __ALIGN_BEGIN struct uvc_streaming_control videoCommitControl __ALIGN_END =
   .wCompQuality = 0,
   .wCompWindowSize = 0,
   .wDelay = 0,
-  .dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(YUYV)),
+  .dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(YUYV)),
   .dwMaxPayloadTransferSize = VIDEO_PACKET_SIZE,
   .dwClockFrequency = 0,
   .bmFramingInfo = 0,
@@ -132,7 +132,7 @@ __ALIGN_BEGIN struct uvc_streaming_control videoProbeControl __ALIGN_END =
   .wCompQuality = 0,
   .wCompWindowSize = 0,
   .wDelay = 0,
-  .dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(YUYV)),
+  .dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(YUYV)),
   .dwMaxPayloadTransferSize = VIDEO_PACKET_SIZE,
   .dwClockFrequency = 0,
   .bmFramingInfo = 0,
@@ -449,23 +449,23 @@ static int8_t UVC_VS_ControlGet  (uint8_t cmd, uint8_t* pbuf, uint16_t length, u
         switch(videoProbeControl.bFormatIndex) {
         case VS_FMT_INDEX(NV12):
         case VS_FMT_INDEX(YU12):
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(NV12));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(NV12));
           break;
         case VS_FMT_INDEX(GREY):
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(GREY));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(GREY));
           break;
         case VS_FMT_INDEX(Y16):
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(Y16));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(Y16));
           break;
         case VS_FMT_INDEX(BGR3):
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(BGR3));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(BGR3));
           break;
         case VS_FMT_INDEX(RGB565):
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(RGB565));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(RGB565));
           break;
         case VS_FMT_INDEX(YUYV):
         default:
-          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(80,60,VS_FMT_SIZE(YUYV));
+          rtnBuf->dwMaxVideoFrameSize = MAX_FRAME_SIZE(OUTPUT_LINE_LENGTH, OUTPUT_LINES,VS_FMT_SIZE(YUYV));
           break;
         }
       }


### PR DESCRIPTION
…t backward compatible with Lepton 2. One should not see the loss of sync that usually happens with the current HEAD of PT-1 code for Lepton 3. A big caveat to being able to use this is that one needs to have the newer STM on the PT-1 i.e. the STM32F412CGU as opposed to the STM32F411CEU which was used on older STMs. A big change was modifying the linker script to ensure that we were utilizing the RAM on the F412CGU which allows our buffering between SPI and UVC transfers to happen glitch-free.