### PR TITLE
fix bug with AgcHeqLinearPercent

### DIFF
--- a/Src/usbd_uvc_lepton_xu.c
+++ b/Src/usbd_uvc_lepton_xu.c
@@ -88,7 +88,6 @@ static int8_t getAttributeLen_AGC(uint16_t module_register, uint16_t *pbuf)
   case LEP_CID_AGC_POLICY:
   case LEP_CID_AGC_HEQ_SCALE_FACTOR:
   case LEP_CID_AGC_CALC_ENABLE_STATE:
-  case LEP_CID_AGC_HEQ_LINEAR_PERCENT:
     *pbuf = 4;
     break;
   default:


### PR DESCRIPTION
Checksum was being calculated incorrectly because
of an incorrect word length