### PR TITLE
Stop overwriting Rad Enable state

### DIFF
--- a/Inc/lepton_i2c.h
+++ b/Inc/lepton_i2c.h
@@ -13,7 +13,7 @@ HAL_StatusTypeDef lepton_read_data(uint8_t * data);
 HAL_StatusTypeDef init_lepton_command_interface(void);
 HAL_StatusTypeDef disable_lepton_agc();
 HAL_StatusTypeDef enable_lepton_agc();
-HAL_StatusTypeDef restore_cached_values();
+HAL_StatusTypeDef disable_rgb888();
 HAL_StatusTypeDef disable_telemetry(void);
 HAL_StatusTypeDef enable_telemetry(void);
 HAL_StatusTypeDef get_scene_stats(uint16_t *min, uint16_t *max, uint16_t *avg);

--- a/Inc/lepton_i2c.h
+++ b/Inc/lepton_i2c.h
@@ -13,6 +13,7 @@ HAL_StatusTypeDef lepton_read_data(uint8_t * data);
 HAL_StatusTypeDef init_lepton_command_interface(void);
 HAL_StatusTypeDef disable_lepton_agc();
 HAL_StatusTypeDef enable_lepton_agc();
+HAL_StatusTypeDef restore_cached_values();
 HAL_StatusTypeDef disable_telemetry(void);
 HAL_StatusTypeDef enable_telemetry(void);
 HAL_StatusTypeDef get_scene_stats(uint16_t *min, uint16_t *max, uint16_t *avg);

--- a/Src/lepton_i2c.c
+++ b/Src/lepton_i2c.c
@@ -286,23 +286,23 @@ HAL_StatusTypeDef enable_telemetry(void)
   return HAL_OK;
 }
 
-// Using END as an illegal value to mean this has never been set
-LEP_RAD_ENABLE_E cachedTLinearState = LEP_END_RAD_ENABLE;
+// Using END as an illegal value to mean this isn't currently caching a value
+static LEP_RAD_ENABLE_E cached_TLinear_state = LEP_END_RAD_ENABLE;
 
 HAL_StatusTypeDef restore_cached_values()
 {
   LEP_RESULT result;
 
   // if we have cached a tlinear value, set it back to that value
-  if (LEP_END_RAD_ENABLE != cachedTLinearState) {
+  if (LEP_END_RAD_ENABLE != cached_TLinear_state) {
     // clear the cached tlinear state so we don't overwrite it multiple times
     // (this function will get called everytime any stream stops)
-    result = LEP_SetRadTLinearEnableState(&hport_desc, cachedTLinearState);
+    result = LEP_SetRadTLinearEnableState(&hport_desc, cached_TLinear_state);
     if (result != LEP_OK) {
-      DEBUG_PRINTF("Could not disable radiometry %d\r\n", result);
+      DEBUG_PRINTF("Could not restore tlinear setting %d\r\n", result);
       return HAL_ERROR;
     }
-    cachedTLinearState = LEP_END_RAD_ENABLE;
+    cached_TLinear_state = LEP_END_RAD_ENABLE;
   }
 
   return HAL_OK;
@@ -317,9 +317,9 @@ HAL_StatusTypeDef enable_rgb888(LEP_PCOLOR_LUT_E pcolor_lut)
   LEP_GetOemVideoOutputFormat(&hport_desc, &fmt);
   DEBUG_PRINTF("Current format: %d\r\n", fmt);
 
-  // cache the old tlinear state so we can set it back if we got to raw14
-  if (cachedTLinearState == LEP_END_RAD_ENABLE) {
-    result = LEP_GetRadTLinearEnableState(&hport_desc, &cachedTLinearState);
+  // cache the old tlinear state so we can set it back if we go to raw14
+  if (cached_TLinear_state == LEP_END_RAD_ENABLE) {
+    result = LEP_GetRadTLinearEnableState(&hport_desc, &cached_TLinear_state);
     if (result != LEP_OK) {
       DEBUG_PRINTF("Could not get tlinear state %d\r\n", result);
       return HAL_ERROR;

--- a/Src/lepton_task.c
+++ b/Src/lepton_task.c
@@ -106,6 +106,7 @@ PT_THREAD( lepton_task(struct pt *pt))
 	static int transferring_timer = 0;
 	static uint8_t current_segment = 0;
 	static uint8_t last_end_line = 0;
+	static uint8_t has_started_a_stream = 0;
 	curtick = last_tick = HAL_GetTick();
 
 #ifdef THERMAL_DATA_UART
@@ -119,13 +120,16 @@ PT_THREAD( lepton_task(struct pt *pt))
 		if (g_uvc_stream_status == 0)
 		{
 			lepton_low_power();
-			if (g_format_y16)
+			if (has_started_a_stream)
 			{
-				// no cleanup after y16
-			}
-			else
-			{
-				disable_rgb888();
+				if (g_format_y16)
+				{
+					// no cleanup after y16
+				}
+				else
+				{
+					disable_rgb888();
+				}
 			}
 
 			// Start slow blink (1 Hz)
@@ -154,6 +158,7 @@ PT_THREAD( lepton_task(struct pt *pt))
 				enable_lepton_agc();
 				enable_rgb888((LEP_PCOLOR_LUT_E)-1); // -1 means attempt to continue using the current palette (PcolorLUT)
 			}
+			has_started_a_stream = 1;
 
 			// flush out any old data
 			while (dequeue_lepton_buffer() != NULL) {}

--- a/Src/lepton_task.c
+++ b/Src/lepton_task.c
@@ -119,6 +119,7 @@ PT_THREAD( lepton_task(struct pt *pt))
 		if (g_uvc_stream_status == 0)
 		{
 			lepton_low_power();
+			restore_cached_values();
 
 			// Start slow blink (1 Hz)
 			while (g_uvc_stream_status == 0)

--- a/Src/lepton_task.c
+++ b/Src/lepton_task.c
@@ -119,7 +119,14 @@ PT_THREAD( lepton_task(struct pt *pt))
 		if (g_uvc_stream_status == 0)
 		{
 			lepton_low_power();
-			restore_cached_values();
+			if (g_format_y16)
+			{
+				// no cleanup after y16
+			}
+			else
+			{
+				disable_rgb888();
+			}
 
 			// Start slow blink (1 Hz)
 			while (g_uvc_stream_status == 0)


### PR DESCRIPTION
The firmware previously set the radiometry to ENABLE every time
Y16 streaming started. The new behavior is to leave radiometry
alone and to turn TLinear off when rgb888 starts and restore
the TLinear state when rgb888 stops.