### PR TITLE
Fix Y16 format type descriptor's count of frame descriptors.

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/uvc_desc_vs_l2.h
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/uvc_desc_vs_l2.h
@@ -49,7 +49,7 @@
   },
 .uvc_vs_frames_format_2 =
   {
-    .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(Y16, 1),
+    .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(Y16, 2),
     .uvc_vs_frame  = { UVC_FRAME_FORMAT(VS_FRAME_INDEX_DEFAULT, Y16, 80, 60),
                        UVC_FRAME_FORMAT(VS_FRAME_INDEX_TELEMETRIC, Y16, 80, 63) },
     .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),

--- a/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/uvc_desc_vs_l3.h
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/video/Inc/uvc_desc_vs_l3.h
@@ -49,7 +49,7 @@
   },
 .uvc_vs_frames_format_2 =
   {
-    .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(Y16, 1),
+    .uvc_vs_format = UVC_FORMAT_UNCOMPRESSED_DESCRIPTOR(Y16, 2),
     .uvc_vs_frame  = { UVC_FRAME_FORMAT(VS_FRAME_INDEX_DEFAULT, Y16, 160, 120),
                        UVC_FRAME_FORMAT(VS_FRAME_INDEX_TELEMETRIC, Y16, 160, 122) },
     .uvc_vs_color  = UVC_COLOR_MATCHING_DESCRIPTOR(),


### PR DESCRIPTION
The Y16 format descriptor has a value of 1 for the number of frame descriptors, while there are actually 2 (with and without telemetry data included).
Correspondingly, the output of usbtreeview below shows an error because two frame descriptors are detected which is a mismatch ( 2 != 1).

```
        ------- VS Uncompressed Format Type Descriptor --------
bLength                  : 0x1B (27 bytes)
bDescriptorType          : 0x24 (Video Streaming Interface)
bDescriptorSubtype       : 0x04 (Uncompressed Format Type)
bFormatIndex             : 0x02
bNumFrameDescriptors     : 0x01
guidFormat               : {20363159-0000-0010-8000-00AA00389B71} (unknown)
bBitsPerPixel            : 0x10
bDefaultFrameIndex       : 0x01
bAspectRatioX            : 0x00
bAspectRatioY            : 0x00
bmInterlaceFlags         : 0x00
 D0 IL stream or variable: 0 (no)
 D1 Fields per frame     : 0 (2 fields)
 D2 Field 1 first        : 0 (no)
 D3 Reserved             : 0
 D4..5 Field pattern     : 0 (Field 1 only)
 D6..7 Display Mode      : 0 (Bob only)
bCopyProtect             : 0x00 (No restrictions)
*!*ERROR:  Found 2 frame descriptors (should be 1)

        -------- VS Uncompressed Frame Type Descriptor --------
---> This is the Default (optimum) Frame index
bLength                  : 0x1E (30 bytes)
bDescriptorType          : 0x24 (Video Streaming Interface)
bDescriptorSubtype       : 0x05 (Uncompressed Frame Type)
bFrameIndex              : 0x01
bmCapabilities           : 0x02
wWidth                   : 0x00A0 (160)
wHeight                  : 0x0078 (120)
dwMinBitRate             : 0x002A3000 (345.5 KB/s)
dwMaxBitRate             : 0x002A3000 (345.5 KB/s)
dwMaxVideoFrameBufferSize: 0x00009600
dwDefaultFrameInterval   : 0x0010F447 (111 ms -> 9.00 fps)
bFrameIntervalType       : 0x01
adwFrameInterval[1]      : 0x0010F447 (111 ms -> 9.00 fps)

        -------- VS Uncompressed Frame Type Descriptor --------
bLength                  : 0x1E (30 bytes)
bDescriptorType          : 0x24 (Video Streaming Interface)
bDescriptorSubtype       : 0x05 (Uncompressed Frame Type)
bFrameIndex              : 0x02
bmCapabilities           : 0x02
wWidth                   : 0x00A0 (160)
wHeight                  : 0x007A (122)
dwMinBitRate             : 0x002AE400 (351.2 KB/s)
dwMaxBitRate             : 0x002AE400 (351.2 KB/s)
dwMaxVideoFrameBufferSize: 0x00009880
dwDefaultFrameInterval   : 0x0010F447 (111 ms -> 9.00 fps)
bFrameIntervalType       : 0x01
adwFrameInterval[1]      : 0x0010F447 (111 ms -> 9.00 fps)
```
